### PR TITLE
Add ROMS example dataset

### DIFF
--- a/ROMS_example.md5
+++ b/ROMS_example.md5
@@ -1,0 +1,1 @@
+1f65e1ebcf8fb321e5f1ebd1471b7c02


### PR DESCRIPTION
 - [x] added a ``.md5`` checksum file generated with ``make_check_sums.py`` 

Added ROMS dataset to go along with the ROMS Ocean Model example notebook.