### PR TITLE
Generate HTML reprs for datasets and push to pages

### DIFF
--- a/.github/workflows/build_page.py
+++ b/.github/workflows/build_page.py
@@ -1,0 +1,80 @@
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "cfgrib>=0.9.15.1",
+#     "netcdf4>=1.7.4",
+#     "pooch>=1.9.0",
+#     "xarray>=2026.4.0",
+# ]
+# ///
+from pathlib import Path
+
+import xarray as xr
+
+NON_DATA_FILES = [
+    ".DS_Store",
+    "README.md",
+    "LICENSE",
+    "CODE_OF_CONDUCT.md",
+    "CONTRIBUTING.md",
+    ".git",
+    "references",
+    ".github",
+    ".gitignore",
+    "pages",
+]
+NON_DATA_SUFFIXES = [".md5", ".py", ".idx"]
+
+BASE_DIR = Path(__file__).parent.parent.parent
+PAGES_DIR = BASE_DIR / "pages"
+
+
+def main():
+    files = sorted(
+        [
+            f
+            for f in BASE_DIR.glob("*")
+            if f.suffix not in NON_DATA_SUFFIXES and f.name not in NON_DATA_FILES
+        ]
+    )
+
+    index_links = []
+
+    for f in files:
+        print(f"Processing {f}...")
+
+        try:
+            ds = xr.open_datatree(f)
+        except ValueError:
+            print(f"Could not open {f} as a datatree, trying as a dataset...")
+            ds = xr.open_dataset(f)
+
+        github_download_link = f'<a href="https://github.com/pydata/xarray-data/raw/refs/heads/master/{f.name}">{f.name}</a>'
+
+        pages_path = PAGES_DIR / f"{f.stem}.html"
+        pages_path.parent.mkdir(exist_ok=True)
+        with pages_path.open("w") as ds_page:
+            ds_page.write(
+                f"<!DOCTYPE html><html><head><meta charset='utf-8'>"
+                f"<title>{f.stem}</title></head><body>"
+                f"<h1>{f.stem}</h1><p>Download: {github_download_link}</p>"
+            )
+            ds_page.write(ds._repr_html_())
+            ds_page.write("</body></html>")
+
+        index_links.append(
+            f'<li><a href="./{f.stem}.html">{f.stem}</a>({github_download_link})</li>'
+        )
+
+    with (PAGES_DIR / "index.html").open("w") as index_page:
+        index_page.write(
+            "<!DOCTYPE html><html><head><meta charset='utf-8'>"
+            "<title>Xarray Tutorial Datasets</title></head><body>"
+            "<h1>Xarray Tutorial Datasets</h1><ul>"
+        )
+        index_page.write("\n".join(index_links))
+        index_page.write("</ul></body></html>")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/build_pages.yml
+++ b/.github/workflows/build_pages.yml
@@ -1,0 +1,38 @@
+name: Deploy dataset HTML to GitHub Pages
+
+on: push
+
+concurrency:
+    group: pages
+    cancel-in-progress: true
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v6.0.2
+
+            - uses: astral-sh/setup-uv@v8.1.0
+
+            - name: Build pages
+              run: uv run .github/workflows/build_page.py
+
+            - uses: actions/upload-pages-artifact@v5.0.0
+              with:
+                  path: pages/
+
+    deploy:
+        needs: build
+        runs-on: ubuntu-latest
+        if: ${{ github.ref == 'refs/heads/master' }}
+        permissions:
+            contents: read
+            pages: write
+            id-token: write
+        environment:
+            name: github-pages
+            url: ${{ steps.deploy.outputs.page_url }}
+        steps:
+            - name: Deploy to GitHub Pages
+              id: deploy
+              uses: actions/deploy-pages@v5.0.0

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+pages
+
+# .gribs generate index files that we don't want to track
+*.idx

--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@
 
 This repository exists to hold example datasets for [xarray](http://xarray.pydata.org) (e.g., as used in the
 documentation) that would bloat the [main repository](https://github.com/pydata/xarray) if included there.
+
+View the dataset represnetations at [pydata.github.io/xarray-data/](https://pydata.github.io/xarray-data/). They should be updated on every push to master of a new dataset.


### PR DESCRIPTION
I got inspired while trying to find a good dataset to test an Xpublish PR.

This adds a script and Github Actions workflow to build and index and pages for each dataset in the repo, and then publishes them to Github Pages on pushes/merges to `master`.

index page:

![image.png](https://app.gitbutler.com/uploads/9be142ee-ac9d-41b3-bd67-93af804db93b)

individual dataset preview (`/precipitation.html`):

![image.png](https://app.gitbutler.com/uploads/d1bc7f1c-222d-4872-9b11-0ac152cf354b)

Closes https://github.com/pydata/xarray-data/issues/39